### PR TITLE
Add browser specific installation guide with screenshot placeholders

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1,36 +1,68 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #f9fafb;
+}
+
 .installation-guide {
-    max-width: 900px;
-    margin: 40px auto;
-    padding: 20px;
+  max-width: 900px;
+  margin: 40px auto;
+  padding: 20px;
 }
 
 details {
-    margin-bottom: 16px;
-    border: 1px solid #ddd;
-    border-radius: 8px;
-    padding: 10px 14px;
+  margin-bottom: 16px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 12px;
+  background: #ffffff;
 }
 
 summary {
-    font-weight: 600;
-    cursor : pointer;
-    font-size: 1.1rem;
+  font-size: 1.1rem;
+  font-weight: 600;
+  cursor: pointer;
 }
 
-.screenshot-placeholder {
-    margin: 8px 0;
-    padding: 10px;
-    background: #f5f5f5;
-    font-style: italic;
-    border-left: 4px solid #4f46e5;
+code {
+  background: #f1f1f1;
+  padding: 2px 6px;
+  border-radius: 4px;
 }
 
 .copy-btn {
-    margin-left: 8px;
-    cursor: pointer;
+  margin-left: 6px;
+  cursor: pointer;
+}
+
+.screenshot-placeholder {
+  margin: 8px 0;
+  padding: 10px;
+  background: #f5f5f5;
+  font-style: italic;
+  border-left: 4px solid #4f46e5;
 }
 
 .note {
-    font-size: 0.9rem;
-    color: #555;
+  font-size: 0.9rem;
+  color: #555;
+}
+
+.warning {
+  margin-top: 10px;
+  padding: 10px;
+  background: #fff3cd;
+  border-left: 4px solid #ff9800;
+}
+
+.doc-link {
+  margin-top: 10px;
+}
+
+.doc-link a {
+  color: #2563eb;
+  text-decoration: none;
+}
+
+.doc-link a:hover {
+  text-decoration: underline;
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,115 +1,226 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>SS-capture</title>
-    <link rel="stylesheet" href = "css/style.css">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SS-capture</title>
+
+  <!-- CSS -->
+  <link rel="stylesheet" href="css/style.css">
 </head>
+
 <body>
-    <section class = "installation-guide">
-        <h2>Installation Guide</h2>
-        <p>
-            Follow The Steps Below To Install The <strong>SS-Capture</strong> Browser extension. Each Section is specific to a browser and written for beginners.
+
+<section class="installation-guide">
+  <h2>Installation Guide</h2>
+
+  <p>
+    Follow the steps below to install the <strong>SS-Capture</strong> browser extension.
+    Each section is specific to a browser and written for beginners.
+  </p>
+
+  <!-- Chrome Accordion -->
+  <details open>
+    <summary>Install on Chrome</summary>
+
+    <ol>
+      <li>
+        Download the latest release from the GitHub <strong>Releases</strong> page.
+        <div class="screenshot-placeholder">
+          [Screenshot: GitHub Releases Page]
+        </div>
+      </li>
+
+      <li>
+        Open Chrome and go to:
+        <code>chrome://extensions/</code>
+        <button class="copy-btn" data-copy="chrome://extensions/">Copy</button>
+
+        <div class="screenshot-placeholder">
+          [Screenshot: Chrome Extensions Page]
+        </div>
+      </li>
+
+      <li>
+        Enable <strong>Developer mode</strong> using the toggle at the top-right corner.
+        <p class="note">
+          Developer mode allows you to load extensions manually for development or testing.
         </p>
 
-        <!--Chrome/Edge Accordion-->
-        <details open>
-            <summary>Install on Chrome/Edge</summary>
-            <ol>
-                <li>
-                    Download the Latest Release From the GitHub <strong>Releases</strong> page.
-                    <div class=""screenshot-placeholder">[Screenshot: GitHub Releases Page]
-                    </div>
-                </li>
+        <div class="screenshot-placeholder">
+          [Screenshot: Developer Mode Enabled]
+        </div>
+      </li>
 
-                <li>
-                    Open Chrome or Edge and go to:
-                    <code>chrome://extensions/</code>
-                    <button class ="copy-btn" data-copy ="chrome://extensions/">Copy</button>
-                    <div class ="screenshot-placeholder">[Screenshot: Chrome Extensions Page]</div>
-                </li>
+      <li>
+        Click <strong>Load unpacked</strong> and select the
+        <code>dist/chrome</code> folder.
+        <div class="screenshot-placeholder">
+          [Screenshot: Load Unpacked Folder]
+        </div>
+      </li>
 
-                <li>
-                    Enable <strong>Developer mode</strong> using the toggle at the top-right corner.
-                    <p class ="note">
-                        Developer Mode Allows You to Load Extensions Manually for Development or Testing.
-                    </p>
-                    <div class = "screenshot-placeholder">[Screenshot: Developer Mode Enabled]</div>
-                </li>
+      <li>
+        The extension will now appear in the extensions list and is ready to use.
+        <div class="screenshot-placeholder">
+          [Screenshot: Extension Installed Successfully]
+        </div>
+      </li>
+    </ol>
 
-                <li>
-                    Click <strong>Load unpacked</strong> and select the <code>dist/chrome</code> (or <code>dist/edge</code>) folder.
-                    <div class = "screenshot-placeholder">[Screenshot: Load Unpacked Folder]</div>
-                </li>
+    <div class ="warning">
+        <strong>Common mistake:</strong> Do not select individual files. 
+        Always select the full <code>dist/chrome</code> folder.
+    </div>
 
-                <li>
-                    The Extension will now appear in the Extensions List and is Ready to use.
-                    <div class ="screenshot-placeholder">[Screenshot: Extension Installed Successfully</div>
-                </li>
-            </ol>
-        </details>
+    <p class = "doc-link">
+        Official Docs:
+        <a href = "https://developer.chrome.com/docs/extensions/" target = "_blank">
+            Chrome Extension Documentation
+        </a>
+    </p>
+  </details>
 
+  <!-- Edge Accordion -->
+  <details>
+    <summary>Install on Microsoft Edge</summary>
 
-        <!--Firefox Accordion-->
-        <details>
-            <summary>Install on Firefox</summary>
-            <ol>
-                <li>
-                    Download the Latest Release from the GitHub <strong>Releases</strong> page.
-                    <div class ="screenshot-placeholder">[Screenshot: GitHub Releases Page</div>
-                </li>
+    <ol>
+      <li>
+        Download the latest release from the GitHub <strong>Releases</strong> page.
+        <div class="screenshot-placeholder">
+          [Screenshot: GitHub Releases Page]
+        </div>
+      </li>
 
-                <li>
-                    Extract the ZIP file to a known location.
-                    <div class="screenshot-placeholder">[Screenshot: Extract ZIP File]</div>
-                </li>
+      <li>
+        Open Microsoft Edge and go to:
+        <code>edge://extensions/</code>
+        <button class="copy-btn" data-copy="edge://extensions/">Copy</button>
 
-                <li>
-                    Open Firefox and navigate to:
-                    <code>about:debugging</code>
-                    <button class ="copy-btn" data-copy = "about:debugging">Copy</button>
-                    <div class = "screenshot-placeholder">[Screenshot: The Firefox Tab]</div>
-                </li>
+        <div class="screenshot-placeholder">
+          [Screenshot: Edge Extensions Page]
+        </div>
+      </li>
 
-                <li>
-                    Click <strong>Load Temporary Add-on</strong> and select 
-                    <code>manifest.json</code> from the <code>dist/firefox</code> folder.
-                    <div class = "screenshot-placeholder">[Screenshot: Load Temporary Add-on]</div>
-                </li>
+      <li>
+        Enable <strong>Developer mode</strong> using the toggle at the bottom-left corner.
+        <div class="screenshot-placeholder">
+          [Screenshot: Developer Mode Enabled]
+        </div>
+      </li>
 
-                <li>
-                    The extension is now loaded temporarily and will remain active until Firefox is closed.
-                    <div class = "screenshot-placeholder">[Screenshot: Firefox Extension Loaded]</div>
-                </li>
-            </ol>
-        </details>
+      <li>
+        Click <strong>Load unpacked</strong> and select the
+        <code>dist/edge</code> folder.
+        <div class="screenshot-placeholder">
+          [Screenshot: Load Unpacked Folder]
+        </div>
+      </li>
 
+      <li>
+        The extension will now appear in the extensions list and is ready to use.
+        <div class="screenshot-placeholder">
+          [Screenshot: Extension Installed Successfully]
+        </div>
+      </li>
+    </ol>
 
-        <!--Troubleshooting-->
-        <details>
-            <summary>Troubleshooting</summary>
-            <ul>
-                <li>
-                    If the extension does not appear, confirm that <strong>Developer mode</strong> is enabled.
-                </li>
+    <p class = "doc-link">
+        Official Docs:
+        <a href = "https://learn.microsoft.com/en-us/microsoft-edge/extensions-chromium/" target = "_blank">
+            Edge Extension Documentation
+        </a>
+    </p>
+  </details>
 
-                <li>
-                    Ensure you selected the correct folder:
-                    <code>dist/chrome</code>, <code>dist/edge</code>, or <code>dist/firefox</code>
-                </li>
+  <!-- Firefox Accordion -->
+  <details>
+    <summary>Install on Firefox</summary>
 
-                <li>
-                    Firefox temporary add-ons are removed when the browser is restarted.
-                </li>
+    <ol>
+      <li>
+        Download the latest release from the GitHub <strong>Releases</strong> page.
+        <div class="screenshot-placeholder">
+          [Screenshot: GitHub Releases Page]
+        </div>
+      </li>
 
-                <li>
-                    Chrome internal pages such as 
-                    <code>chrome://</code> cannot be captured due to browser security restrictions.
-                </li>
-            </ul>
-        </details>
-    </section>
-    <script src="js/script.js"></script>
+      <li>
+        Extract the ZIP file to a known location.
+        <div class="screenshot-placeholder">
+          [Screenshot: Extract ZIP File]
+        </div>
+      </li>
+
+      <li>
+        Open Firefox and navigate to:
+        <code>about:debugging</code>
+        <button class="copy-btn" data-copy="about:debugging">Copy</button>
+
+        <div class="screenshot-placeholder">
+          [Screenshot: Firefox Debugging Page]
+        </div>
+      </li>
+
+      <li>
+        Click <strong>This Firefox</strong>.
+      </li>
+
+      <li>
+        Click <strong>Load Temporary Add-on</strong> and select
+        <code>manifest.json</code> from the <code>dist/firefox</code> folder.
+        <div class="screenshot-placeholder">
+          [Screenshot: Load Temporary Add-on]
+        </div>
+      </li>
+
+      <li>
+        The extension is now loaded temporarily and will remain active until Firefox is closed.
+        <div class="screenshot-placeholder">
+          [Screenshot: Firefox Extension Loaded]
+        </div>
+      </li>
+    </ol>
+
+    <div class = "warning">
+        Firefox temporary add-ons are removed after browser restart.
+    </div>
+
+    <p class = "doc-link">
+        Official Docs:
+        <a href = "https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions" target = "_blank">Firefox Extension Documentation</a>
+    </p>
+  </details>
+
+  <!-- Troubleshooting -->
+  <details>
+    <summary>Troubleshooting</summary>
+
+    <ul>
+      <li>
+        If the extension does not appear, confirm that <strong>Developer mode</strong> is enabled.
+      </li>
+
+      <li>
+        Ensure you selected the correct folder:
+        <code>dist/chrome</code>, <code>dist/edge</code>, or <code>dist/firefox</code>.
+      </li>
+
+      <li>
+        Firefox temporary add-ons are removed when the browser is restarted.
+      </li>
+
+      <li>
+        Chrome and Edge internal pages such as <code>chrome://</code> and <code>edge://</code>
+        cannot be captured due to browser security restrictions.
+      </li>
+    </ul>
+  </details>
+
+</section>
+
+<!-- JavaScript -->
+<script src="js/script.js"></script>
 </body>
 </html>

--- a/docs/js/script.js
+++ b/docs/js/script.js
@@ -1,6 +1,11 @@
-document.querySelectorAll('.copy-btn').forEach(btn => {
-        btn.addEventListener('click', () => {navigator.clipboard.writeText(btn.dataset.copy);
-            btn.textContent = 'Copied!';
-            setTimeout(() => (btn.textContent = 'Copy'), 1500);
-        });
+document.querySelectorAll('.copy-btn').forEach(button => {
+  button.addEventListener('click', () => {
+    const text = button.getAttribute('data-copy');
+    navigator.clipboard.writeText(text);
+
+    button.textContent = 'Copied!';
+    setTimeout(() => {
+      button.textContent = 'Copy';
+    }, 1500);
+  });
 });


### PR DESCRIPTION
## Description
This pull request adds a clear, beginner-friendly installation guide for the SS-Capture browser extension. The guide is structured using an accordion interface to improve readability and make browser-specific instructions easy to follow.

## Changes Made
- Created a structured installation guide using accordion components
- Added separate installation steps for Chrome, Edge, and Firefox
- Included screenshot placeholders for each major step
- Added copy buttons for internal browser URLs (e.g., chrome://extensions/)
- Added warning callouts for common installation mistakes
- Linked official browser documentation for further reference

## Source of Content
All installation steps are derived from the existing README.md to ensure accuracy and consistency.

## Screenshots
Placeholder sections are included for screenshots and can be replaced with actual images in future updates.

## Related Issue
Fixes #6  

## Notes
- No functional code or extension logic was modified
- This PR focuses only on improving documentation and user experience
