### PR TITLE
feat: add context menu support for all capture modes

### DIFF
--- a/ss-capture/scripts/build.js
+++ b/ss-capture/scripts/build.js
@@ -94,7 +94,8 @@ async function generateManifest(browser, env) {
       "scripting",
       "downloads",
       "storage",
-      "unlimitedStorage"
+      "unlimitedStorage",
+      "contextMenus"
     ],
     host_permissions: [
       "<all_urls>"

--- a/ss-capture/src/manifest.json
+++ b/ss-capture/src/manifest.json
@@ -8,7 +8,8 @@
     "scripting",
     "downloads",
     "storage",
-    "unlimitedStorage"
+    "unlimitedStorage",
+    "contextMenus"
   ],
   "optional_host_permissions": [
     "<all_urls>"


### PR DESCRIPTION
### Summary
This PR implements right-click context menu support to invoke SS-Capture directly from any webpage, as requested in Issue #75. Users can now trigger capture modes without opening the extension popup or remembering keyboard shortcuts.

---

### Key Changes

- **Context Menu Integration:** Added three new options to the browser context menu:
  - Capture Full Page
  - Capture Visible Area
  - Capture Selected Element

- **Permissions:** Added the `contextMenus` permission to `manifest.json` and updated the manifest generator in `build.js`.

- **Background Logic:** Implemented a robust click handler in `background.js` that injects/activates content scripts and manages permission requests.

- **Visual Feedback:** Added shutter-style visual feedback and toast notifications to indicate when captures begin and complete.

---

### Testing Completed

- **Build Validation:** Successfully ran `npm run build` and `npm run validate`. Confirmed that all generated manifest files correctly include the `contextMenus` permission.

- **Functional Testing:**
  - Verified context menu items appear correctly after installation.
  - Confirmed each mode (Full Page, Visible Area, Selected Element) works from the right-click menu.
  - Ensured toast notifications and visual capture indicators behave as expected during captures.

- **Sync:** Resynced with the `main` branch to prevent merge conflicts.

---

### Related Issue
Closes #75 
