### PR TITLE
Add dark/light theme toggle for docs

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -32,6 +32,18 @@ html {
   --glass: blur(14px);
 }
 
+/* ===== DARK MODE VARIABLES ===== */
+body.dark {
+  --bg-color: linear-gradient(135deg, #0f172a, #1a1f35);
+  --card-bg: rgba(30, 41, 59, 0.85);
+  --primary: #a5b4fc;
+  --secondary: #e2e8f0;
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --border: rgba(255, 255, 255, 0.08);
+  --warning: #7f1d1d;
+}
+
 /* ===== LOGO ===== */
 .logo {
   display: flex;
@@ -73,6 +85,33 @@ body {
   box-shadow: 0 10px 30px rgba(0,0,0,0.05);
 }
 
+body.dark .navbar {
+  background: rgba(15, 23, 42, 0.8);
+}
+
+/* ===== THEME TOGGLE BUTTON ===== */
+#theme-toggle {
+  background: none;
+  border: 1px solid var(--border);
+  padding: 8px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 1.2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text);
+  transition: background-color 0.3s ease, border-color 0.3s ease;
+}
+
+#theme-toggle:hover {
+  background-color: var(--card-bg);
+}
+
+#theme-toggle:active {
+  transform: scale(0.95);
+}
+
 .nav-links a {
   position: relative;
   padding-bottom: 4px;
@@ -101,6 +140,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 15px;
 }
 
 .logo {
@@ -202,6 +242,11 @@ code {
   font-size: 0.9rem;
 }
 
+body.dark code {
+  background: #334155;
+  color: #e2e8f0;
+}
+
 .copy-btn {
   margin-left: 8px;
   padding: 5px 12px;
@@ -242,6 +287,10 @@ code {
   background: linear-gradient(135deg, #f1f5f9, #e0e7ff);
   border: 1px dashed var(--border);
   font-style: italic;
+}
+
+body.dark .screenshot-placeholder {
+  background: linear-gradient(135deg, #1e293b, #334155);
 }
 .warning {
   animation: pulse 2s infinite;

--- a/docs/index.html
+++ b/docs/index.html
@@ -21,6 +21,11 @@
       <li><a href="https://github.com/HarshYadav152/ss-capture">GitHub</a></li>
       <li><a href="https://github.com/HarshYadav152/ss-capture/discussions">Support</a></li>
     </ul>
+
+    <!-- Dark/Light Mode Toggle Button -->
+    <button id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark/light theme">
+      <span id="theme-icon">🌙</span>
+    </button>
   </div>
 </nav>
 
@@ -441,5 +446,42 @@ function getBotReply(message) {
 }
 </script>
 
+<!-- ===== THEME TOGGLE SCRIPT ===== -->
+<script>
+  // Initialize theme on page load
+  (function initTheme() {
+    // Check localStorage for saved preference
+    const savedTheme = localStorage.getItem('theme');
+    const isDarkMode = savedTheme === 'dark' || 
+      (savedTheme === null && window.matchMedia('(prefers-color-scheme: dark)').matches);
+    
+    // Apply theme
+    if (isDarkMode) {
+      document.body.classList.add('dark');
+      updateThemeIcon('🌙');
+    } else {
+      document.body.classList.remove('dark');
+      updateThemeIcon('☀️');
+    }
+  })();
+
+  // Update icon based on current theme
+  function updateThemeIcon(icon) {
+    const themeIcon = document.getElementById('theme-icon');
+    if (themeIcon) {
+      themeIcon.textContent = icon;
+    }
+  }
+
+  // Toggle theme on button click
+  document.getElementById('theme-toggle').addEventListener('click', function() {
+    document.body.classList.toggle('dark');
+    
+    // Update localStorage and icon
+    const isDark = document.body.classList.contains('dark');
+    localStorage.setItem('theme', isDark ? 'dark' : 'light');
+    updateThemeIcon(isDark ? '🌙' : '☀️');
+  });
+</script>
 
 </html>


### PR DESCRIPTION
## Description
This PR adds a dark/light mode toggle specifically for the documentation site.
The extension code remains untouched.

## Changes Made
- Added a theme toggle button to docs UI
- Implemented dark theme styles using CSS
- Persisted user preference using localStorage

## Screenshots

### Light Mode


### Dark Mode
(paste screenshot here)
<img width="1000" height="500" alt="Screenshot 2026-01-18 113115" src="https://github.com/user-attachments/assets/f044d4d8-3cab-4e40-92ba-089ea0fa43eb" />
<img width="1000" height="500" alt="Screenshot 2026-01-18 113048" src="https://github.com/user-attachments/assets/adbc143b-4c57-4296-aabb-3fafda6636ba" />
